### PR TITLE
tweak VMware initramfs driver list

### DIFF
--- a/lib/vm-functions
+++ b/lib/vm-functions
@@ -230,7 +230,6 @@ configure_mkinitfs_feature_vm_vmware() {
 
   initramfs_entry_initialise "vm-vmware"
   initramfs_entry_add "kernel/drivers/acpi/tiny-power-button.ko*"
-  initramfs_entry_add "kernel/drivers/ata/ata_piix.ko*"
   if [ -n "${image_optimise+x}" ]; then
     initramfs_entry_add "kernel/drivers/gpu/drm/vmwgfx/vmwgfx.ko*"
   else
@@ -239,8 +238,6 @@ configure_mkinitfs_feature_vm_vmware() {
   initramfs_entry_add "kernel/drivers/message/fusion/mptsas.ko*"
   initramfs_entry_add "kernel/drivers/message/fusion/mptspi.ko*"
   initramfs_entry_add "kernel/drivers/scsi/sd_mod.ko*"
-  initramfs_entry_add "kernel/drivers/scsi/virtio_scsi.ko*"
-  initramfs_entry_add "kernel/drivers/scsi/vmw_pvscsi.ko*"
   if [ -n "${remote_unlock_enabled+x}" ]; then
     initramfs_entry_add "kernel/drivers/net/vmxnet3"
   fi


### PR DESCRIPTION
ata_piix and vmw_pvscsi drivers are actually compiled into linux-virt kernel.
