### PR TITLE
Remove use of PARTTYPENAME lsblk field.

### DIFF
--- a/lib/disk-image-functions
+++ b/lib/disk-image-functions
@@ -1671,7 +1671,7 @@ format_and_mount_fs() {
 	    lsblk --ascii --fs "$loop_device" >> "$logfile" 2>&1
 	    write_debug_log "Blkid output:" 2
 	    lsblk \
-	      --output NAME,FSTYPE,LABEL,UUID,FSSIZE,FSAVAIL,FSUSED,FSUSE%,MOUNTPOINT,PARTTYPENAME,PARTLABEL \
+	      --output NAME,FSTYPE,LABEL,UUID,FSSIZE,FSAVAIL,FSUSED,FSUSE%,MOUNTPOINT,PARTLABEL \
 	      "$loop_device" >> "$logfile" 2>&1
 	  }
 	EOF


### PR DESCRIPTION
The PARTTYPENAME field is only used in debug output and some old
versions of util-linux do not support it (including on Ubuntu LTS).
Just remove it.