### PR TITLE
Fixes for `--no-console-user` and serial console

### DIFF
--- a/lib/cli-functions
+++ b/lib/cli-functions
@@ -81,7 +81,7 @@ lvm,\
 mdev,\
 mirror:,\
 no-cloud-configuration,\
-no-console-user:,\
+no-console-user,\
 no-grub-encryption,\
 ntp-servers:,\
 ntp-use-host,\

--- a/lib/vm-functions
+++ b/lib/vm-functions
@@ -352,9 +352,9 @@ default_virtual_settings() {
       serial )
         case $image_arch in
           aarch64 )
-            image_serial_console_name="${CONSTANT_DEFAULT_SERIAL_CONSOLE_PORT_ARM_BASE_NAME}${image_serial_console_port_number}" ;;
+            image_serial_console_name="${CONSTANT_DEFAULT_SERIAL_CONSOLE_PORT_ARM_BASE_NAME}${image_serial_console_port_number:-$CONSTANT_DEFAULT_SERIAL_CONSOLE_PORT_NUMBER}" ;;
           x86 | x86_64 )
-            image_serial_console_name="${CONSTANT_DEFAULT_SERIAL_CONSOLE_PORT_X86_BASE_NAME}${image_serial_console_port_number}" ;;
+            image_serial_console_name="${CONSTANT_DEFAULT_SERIAL_CONSOLE_PORT_X86_BASE_NAME}${image_serial_console_port_number:-$CONSTANT_DEFAULT_SERIAL_CONSOLE_PORT_NUMBER}" ;;
         esac
         image_console_name=$image_serial_console_name
         ;;


### PR DESCRIPTION
Fix a couple of issues I encountered trying to use this to build images

Serial console was being set as `ttyS` not `ttyS0` and `--no-console-user` was messing up parameter parsing