### PR TITLE
Enable support for v3.17

### DIFF
--- a/lib/cli-functions
+++ b/lib/cli-functions
@@ -673,7 +673,7 @@ help\
       --release )
         if [ "$script_type" = "creator" ]; then
           case $2 in
-            3.13 | 3.14 | 3.15 | 3.16 )
+            3.13 | 3.14 | 3.15 | 3.16 | 3.17 )
               image_alpine_release=v$2 ;;
             edge )
               image_alpine_release=$2 ;;
@@ -1035,7 +1035,7 @@ usage() {
     option_help "--physical < pc | rpi2 | rpi3 | rpi4 >" "The type of physical machine to be created."
   fi
   option_help "--ramdisk-directory < directory >" "When '--use-ramdisk' is also specified this value indicates the directory in which to store the ramdisk file."
-  option_help "--release < 3.13 | 3.14 | 3.15 | edge >" "Which Alpine Release to use for the disk image. If not specified then defaults to 'edge'."
+  option_help "--release < 3.13 | 3.14 | 3.15 | 3.16 | 3.17 | edge >" "Which Alpine Release to use for the disk image. If not specified then defaults to 'edge'."
   if [ -n "${image_experimental+x}" ]; then
     option_help "--remote-unlock-network-module < kernel module name >" "Experimental. Specifies the name of the network device kernel module to be loaded."
     option_help "--remote-unlock-ssh-port < port number >" "Experimental. Specifies the TCP port that the temporary SSH daemon should listen on. If not specified then defaults to '22'."

--- a/lib/grub-functions
+++ b/lib/grub-functions
@@ -90,7 +90,7 @@ configure_bootloader_grub() {
       case $image_os_device_media in
         flash | sd | ssd )
           case $image_alpine_release in
-            v3.13 | v3.14 | v3.15 | v3.16 | edge )
+            v3.13 | v3.14 | v3.15 | v3.16 | v3.17 | edge )
               # For older Alpine releases add commit mount option for rootfs
               # when on flash device as this is *not* read from /etc/fstab by
               # initramfs' init when it mounts rootfs.

--- a/lib/mkinitfs-functions
+++ b/lib/mkinitfs-functions
@@ -449,7 +449,7 @@ configure_mkinitfs_feature_base() {
 	EOF
 
     case $image_alpine_release in
-      v3.13 | v3.14 | v3.15 | v3.16 | edge )
+      v3.13 | v3.14 | v3.15 | v3.16 | v3.17 | edge )
         # Use kmod/modprobe from kmod package
         cat <<-'EOF' >> "$run_script"
 	      echo "/sbin/modprobe"
@@ -551,7 +551,7 @@ configure_mkinitfs_feature_base() {
     # base.files
 
     case $image_alpine_release in
-      v3.13 | v3.14 | v3.15 | v3.16 | edge )
+      v3.13 | v3.14 | v3.15 | v3.16 | v3.17 | edge )
         # These mkinitfs versions do not include /etc/modules in initramfs
         if [ -n "${debug_enabled+x}" ]; then
           cat <<-'EOF' >> "$run_script"

--- a/lib/syslinux-functions
+++ b/lib/syslinux-functions
@@ -50,7 +50,7 @@ configure_bootloader_syslinux() {
       case $image_os_device_media in
         flash | sd | ssd )
           case $image_alpine_release in
-            v3.13 | v3.14 | v3.15 | v3.16 | edge )
+            v3.13 | v3.14 | v3.15 | v3.16 | v3.17 | edge )
               # For older Alpine releases add commit mount option for rootfs
               # when on flash device as this is *not* read from /etc/fstab by
               # initramfs' init when it mounts rootfs.


### PR DESCRIPTION
This seems to work for me, I don't know if you have any other specific testing etc.

For the most part, I looked at anywhere you had a special cast for `v3.16` or `edge`, and did what seemed right.

One bit I wasn't sure of, was that you only seem to enable the `ptp` time sync bits for cloud-init when using `edge` and `--experimental` - I've left this alone and only on edge for now as it seemed quite broken otherwise that (attempts at) fixing it should be a whole separate PR on it's own.