### PR TITLE
fix(common-functions): fix device type string

### DIFF
--- a/lib/common-functions
+++ b/lib/common-functions
@@ -765,7 +765,7 @@ get_storage_device_name() {
       _device_name="/dev/nvme0n1" ;;
     sd )
       _device_name="/dev/mmcblk0" ;;
-    virtio_blk )
+    virtio-blk )
       _device_name="/dev/vda" ;;
     * )
       _device_name="/dev/sda" ;;


### PR DESCRIPTION
Fixes dermotbradley/create-alpine-disk-image#55

This is a small fix to determine the correct device name from the device type if executed with `--os-device-type virtio-blk`, most likely introduced during dermotbradley/create-alpine-disk-image#41 refactorings. This is important for the resize-rootfs init.d script to extend the correct device and partition on the first boot.